### PR TITLE
Add support for subaccounts

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -20,6 +20,30 @@ export default function App() {
       description: 'Payment for items in cart',
       logo: 'https://assets.piedpiper.com/logo.png',
     },
+
+    subaccounts: [
+      {
+        // vendor A
+        id: "RS_D87A9EE339AE28BFA2AE86041C6DE70E",
+        transaction_split_ratio: 2,
+        transaction_charge_type: "flat",
+        transaction_charge: 100,
+      },
+      {
+        // vendor B
+        id: "RS_344DD49DB5D471EF565C897ECD67CD95",
+        transaction_split_ratio: 3,
+        transaction_charge_type: "flat",
+        transaction_charge: 100,
+      },
+      {
+        // vendor C
+        id: "RS_839AC07C3450A65004A0E11B83E22CA9",
+        transaction_split_ratio: 5,
+        transaction_charge_type: "flat",
+        transaction_charge: 100,
+      },
+    ],
   };
   
   const handleFlutterPayment = useFlutterwave(config);

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@
  * Check out {@link https://developer.flutterwave.com/docs/flutterwave-standard} for more information.
  */
 
-export interface FlutterWaveProps {
+ export interface FlutterWaveProps {
   /**
    * 	Your transaction reference. This MUST be unique for every transaction
    */
@@ -66,12 +66,25 @@ export interface FlutterWaveProps {
    * function to be called when the payment is completed successfully
    */
   callback: (data: FlutterWaveResponse) => void;
-  
+
   /**
    * function to be called when the mono connection is closed
    */
   onclose: () => void;
   public_key: string;
+  /**
+   * An array of objects containing the subaccount IDs to split the payment into.
+   * e.g subaccounts: [
+      {
+        id: "RS_A8EB7D4D9C66C0B1C75014EE67D4D663",
+        transaction_split_ratio: 2,
+        transaction_charge_type: "flat_subaccount",
+        transaction_charge: 4200,
+      },
+    ]
+    * Check out {@link https://developer.flutterwave.com/docs/collecting-payments/split-payments/} for more information on subaccounts.
+   */
+  subaccounts?: Array<unknown>;
 }
 
 export interface FlutterwaveConfig {
@@ -85,6 +98,7 @@ export interface FlutterwaveConfig {
   redirect_url?: FlutterWaveProps['redirect_url'];
   payment_plan?: FlutterWaveProps['payment_plan'];
   payment_options: FlutterWaveProps['payment_options'];
+  subaccounts?: FlutterWaveProps['subaccounts'];
 }
 
 export interface InitializeFlutterwavePayment {


### PR DESCRIPTION
This PR includes `subaccounts` in the config types to enable split payments.